### PR TITLE
Chore: global font settings using material-ui theme configs

### DIFF
--- a/src/components/play/BreathingCompleted.jsx
+++ b/src/components/play/BreathingCompleted.jsx
@@ -30,6 +30,7 @@ export default function BreathingCompleted({ coins }) {
     localStorage.setItem('coins', updatedCoins.toString());
 
     return (
+
         <div className='flex flex-col justify-center items-center'>
             <div className='text-center text-30px font-bold pt-8'>Congratulations!</div>
             <div className='flex flex-col justify-center items-center'>

--- a/src/index.css
+++ b/src/index.css
@@ -4,12 +4,6 @@
 
 body {
     margin: 0;
-    font-family: "Cabin", sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-    font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-        monospace;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import {
   redirect,
   RouterProvider,
 } from "react-router-dom";
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Root from "./routes/root";
 import ErrorPage from "./routes/error";
 import Layout from "./routes/layout";
@@ -27,6 +28,14 @@ import Mood5 from "./routes/moodTrack/mood5";
 import Mood6 from "./routes/moodTrack/mood6";
 import Mood7 from "./routes/moodTrack/mood7";
 import Mood8 from "./routes/moodTrack/mood8";
+
+
+// Material-UI theme
+const theme = createTheme({
+  typography: {
+    fontFamily: 'Cabin, sans-serif', // Set "Cabin" as the default font family
+  },
+});
 
 const router = createBrowserRouter([
   {
@@ -119,12 +128,9 @@ const router = createBrowserRouter([
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <RouterProvider router={router} />
-    {/*
-        <StyledEngineProvider injectFirst>
-            <App />
-            </StyledEngineProvider>
-    */}
+    <ThemeProvider theme={theme}>
+      <RouterProvider router={router} />
+    </ThemeProvider>
   </React.StrictMode>
 );
 

--- a/src/routes/moodTrack/modal.js
+++ b/src/routes/moodTrack/modal.js
@@ -4,15 +4,15 @@ import { Link } from "react-router-dom";
 const Modal = ({ modalText, showCancelButton, onCancel, onOk, mt, link }) => {
   return (
     <div
-      className={`w-[250px] h-32 flex-col justify-start items-start inline-flex absolute ${mt}`}
+      className={`w-[250px] flex-col justify-start items-start inline-flex absolute ${mt}`}
     >
-      <div className="h-32 bg-white rounded-[10px] shadow flex-col justify-start items-start flex">
+      <div className="bg-white rounded-[10px] shadow flex-col justify-start items-start flex">
         <div className="self-stretch px-4 pt-5 pb-2 justify-start items-start gap-4 inline-flex">
-          <div className="grow shrink basis-0 text-black text-opacity-90 text-base font-normal font-['Cabin'] leading-normal">
+          <div className="grow shrink basis-0 text-black text-opacity-90 text-base font-normal leading-normal">
             {modalText}
           </div>
         </div>
-        <div className="self-stretch p-2 justify-between items-center gap-2 inline-flex">
+        <div className="self-stretch p-5 justify-between items-center gap-2 inline-flex">
           {showCancelButton && (
             <div
               className="w-9 px-2 py-1.5 rounded justify-center items-center gap-2 flex cursor-pointer"


### PR DESCRIPTION
Realized that there were certain material ui components with their predefined styles for font family, so I figured out this would be a better solution to apply global font family settings, instead of doing that using index.css (which would not affect font family for material ui components) :)